### PR TITLE
PANDARIA: Use thanos image in rancher repo

### DIFF
--- a/charts/rancher-thanos/v0.0.1/values.yaml
+++ b/charts/rancher-thanos/v0.0.1/values.yaml
@@ -54,7 +54,7 @@ grafana:
 
 thanos:
   image:
-    repository: thanosio/thanos
+    repository: rancher/thanos
     tag: v0.9.0
     pullPolicy: IfNotPresent
     proxy:


### PR DESCRIPTION
We've mirrored the thanos image: https://hub.docker.com/r/rancher/thanos