### PR TITLE
PANDARIA: update pod count expression

### DIFF
--- a/charts/rancher-thanos/v0.0.2/charts/grafana/dashboards/dashboard.json
+++ b/charts/rancher-thanos/v0.0.2/charts/grafana/dashboards/dashboard.json
@@ -272,7 +272,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(kube_pod_info)",
+          "expr": "sum(kube_pod_status_phase{phase!~\"Succeeded|Failed\"})",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 1,


### PR DESCRIPTION
https://github.com/cnrancher/pandaria/issues/811

Problem:
The number of pods in grafana dashboard includes terminated pods. It differs from the cluster dashboard.

Solution:
Update the expression.