### PR TITLE
PANDARIA: Add GPU monitoring

### DIFF
--- a/charts/rancher-monitoring/v0.1.2000/charts/exporter-gpu-node/Chart.yaml
+++ b/charts/rancher-monitoring/v0.1.2000/charts/exporter-gpu-node/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+description: Provides gpu monitoring for Rancher2.x
+engine: gotpl
+name: exporter-gpu-node
+version: 0.0.2
+maintainers:
+  - name: jianghang8421
+    email: hang.jiang@rancher.com
+sources:
+  - https://github.com/NVIDIA/gpu-monitoring-tools
+appVersion: "1.4.6"
+home: https://github.com/NVIDIA/gpu-monitoring-tools
+keywords:
+  - exporter
+  - prometheus
+  - gpu
+icon: https://coreos.com/sites/default/files/inline-images/Overview-prometheus_0.png

--- a/charts/rancher-monitoring/v0.1.2000/charts/exporter-gpu-node/templates/daemonset.yaml
+++ b/charts/rancher-monitoring/v0.1.2000/charts/exporter-gpu-node/templates/daemonset.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: gpu-dcgm-exporter
+  namespace: cattle-prometheus
+spec:
+  selector:
+    matchLabels:
+      app: gpu-dcgm-exporter
+  template:
+    metadata:
+      labels:
+        app: gpu-dcgm-exporter
+      name: gpu-dcgm-exporter
+    spec:
+      nodeSelector:
+        gpumonitoring.cattle.io: "true"
+      containers:
+        - image: "{{ template "system_default_registry" . }}{{ .Values.image.nodeexporter.repository }}:{{ .Values.image.nodeexporter.tag }}"
+          name: node-exporter
+          args:
+            - "--web.listen-address=0.0.0.0:{{ .Values.ports.metrics.port }}"
+            - "--path.procfs=/host/proc"
+            - "--path.sysfs=/host/sys"
+            - "--collector.textfile.directory=/run/prometheus"
+            - "--no-collector.arp"
+            - "--no-collector.bcache"
+            - "--no-collector.bonding"
+            - "--no-collector.conntrack"
+            - "--no-collector.cpu"
+            - "--no-collector.diskstats"
+            - "--no-collector.edac"
+            - "--no-collector.entropy"
+            - "--no-collector.filefd"
+            - "--no-collector.filesystem"
+            - "--no-collector.hwmon"
+            - "--no-collector.infiniband"
+            - "--no-collector.ipvs"
+            - "--no-collector.loadavg"
+            - "--no-collector.mdadm"
+            - "--no-collector.meminfo"
+            - "--no-collector.netdev"
+            - "--no-collector.netstat"
+            - "--no-collector.nfs"
+            - "--no-collector.nfsd"
+            - "--no-collector.sockstat"
+            - "--no-collector.stat"
+            - "--no-collector.time"
+            - "--no-collector.timex"
+            - "--no-collector.uname"
+            - "--no-collector.vmstat"
+            - "--no-collector.wifi"
+            - "--no-collector.xfs"
+            - "--no-collector.zfs"
+          ports:
+            - name: metrics
+              containerPort: {{ .Values.ports.metrics.port }}
+              hostPort: {{ .Values.ports.metrics.port }}
+          resources:
+            requests:
+              memory: 30Mi
+              cpu: 100m
+            limits:
+              memory: 50Mi
+              cpu: 200m
+          volumeMounts:
+            - name: proc
+              readOnly:  true
+              mountPath: /host/proc
+            - name: sys
+              readOnly: true
+              mountPath: /host/sys
+            - name: collector-textfiles
+              readOnly: true
+              mountPath: /run/prometheus
+        - image: "{{ template "system_default_registry" . }}{{ .Values.image.dcgmexporter.repository }}:{{ .Values.image.dcgmexporter.tag }}"
+          name: nvidia-dcgm-exporter
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+          volumeMounts:
+            - name: collector-textfiles
+              mountPath: /run/prometheus
+
+      hostNetwork: true
+      hostPID: true
+
+      volumes:
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: collector-textfiles
+          emptyDir:
+            medium: Memory

--- a/charts/rancher-monitoring/v0.1.2000/charts/exporter-gpu-node/templates/metrics-service.yaml
+++ b/charts/rancher-monitoring/v0.1.2000/charts/exporter-gpu-node/templates/metrics-service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: gpu-dcgm-exporter
+    monitoring.coreos.com: "true"
+  name: expose-gpu-dcgm-metrics
+  namespace: cattle-prometheus
+spec:
+  clusterIP: None
+  ports:
+    - name: metrics
+      port: {{ .Values.ports.metrics.port }}
+      protocol: TCP
+      targetPort: {{ .Values.ports.metrics.port }}
+  selector:
+    app: gpu-dcgm-exporter
+  type: ClusterIP

--- a/charts/rancher-monitoring/v0.1.2000/charts/exporter-gpu-node/templates/servicemonitor.yaml
+++ b/charts/rancher-monitoring/v0.1.2000/charts/exporter-gpu-node/templates/servicemonitor.yaml
@@ -1,0 +1,30 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: exporter-gpu-dcgm
+  name: exporter-gpu-dcgm-cluster-monitoring
+  namespace: cattle-prometheus
+spec:
+  endpoints:
+    - port: metrics
+      relabelings:
+        - action: replace
+          regex: (.+)
+          replacement: $1
+          sourceLabels:
+            - __meta_kubernetes_pod_host_ip
+          targetLabel: host_ip
+        - action: replace
+          regex: (.+)
+          replacement: $1
+          sourceLabels:
+            - __meta_kubernetes_pod_node_name
+          targetLabel: node
+  namespaceSelector:
+    matchNames:
+      - cattle-prometheus
+  selector:
+    matchLabels:
+      app: gpu-dcgm-exporter
+      monitoring.coreos.com: "true"

--- a/charts/rancher-monitoring/v0.1.2000/charts/exporter-gpu-node/values.yaml
+++ b/charts/rancher-monitoring/v0.1.2000/charts/exporter-gpu-node/values.yaml
@@ -1,0 +1,3 @@
+ports:
+  metrics:
+    port: 9101

--- a/charts/rancher-monitoring/v0.1.2000/requirements.yaml
+++ b/charts/rancher-monitoring/v0.1.2000/requirements.yaml
@@ -83,3 +83,8 @@ dependencies:
     version: 0.0.1
     condition: webhook-receiver.enabled
     repository: "file://./charts/webhook-receiver/"
+
+  - name: exporter-gpu-node
+    version: 0.0.2
+    condition: exporter-gpu-node.enabled
+    repository: "file://./charts/exporter-gpu-node/"

--- a/charts/rancher-monitoring/v0.1.2000/values.yaml
+++ b/charts/rancher-monitoring/v0.1.2000/values.yaml
@@ -407,3 +407,13 @@ webhook-receiver:
   image:
     repository: "cnrancher/webhook-receiver"
     tag: v0.2.4-ent
+
+exporter-gpu-node:
+  enabled: false
+  image:
+    nodeexporter:
+      repository: rancher/prom-node-exporter
+      tag: v0.17.0
+    dcgmexporter:
+      repository: cnrancher/dcgm-exporter
+      tag: 1.4.6


### PR DESCRIPTION
Relate to cnrancher/pandaria#719  , cnrancher/pandaria#721

- GPU monitoring的组件放在system-charts(v0.1.2000)中管理
- 解决无法自动补全全局镜像仓库地址的问题


![image](https://user-images.githubusercontent.com/13497267/89511339-5c67d980-d804-11ea-9ef9-734431959663.png)

