### PR TITLE
Add rancher max version to istio and monitoring app

### DIFF
--- a/charts/rancher-istio/1.4.1000/questions.yaml
+++ b/charts/rancher-istio/1.4.1000/questions.yaml
@@ -1,3 +1,4 @@
 labels:
   rancher.istio.v1.4.1000: 1.4.10
 rancher_min_version: 2.3.8-rc1
+rancher_max_version: 2.4.7

--- a/charts/rancher-istio/1.5.900/questions.yaml
+++ b/charts/rancher-istio/1.5.900/questions.yaml
@@ -1,3 +1,4 @@
 labels:
   rancher.istio.v1.5.900: 1.5.9
 rancher_min_version: 2.4.5-rc1
+rancher_max_version: 2.4.7

--- a/charts/rancher-monitoring/v0.0.7000/questions.yml
+++ b/charts/rancher-monitoring/v0.0.7000/questions.yml
@@ -1,1 +1,2 @@
 rancher_min_version: 2.3.4-rc1
+rancher_max_version: 2.4.7

--- a/charts/rancher-monitoring/v0.1.1000/questions.yml
+++ b/charts/rancher-monitoring/v0.1.1000/questions.yml
@@ -1,1 +1,2 @@
 rancher_min_version: 2.3.4-rc1
+rancher_max_version: 2.4.7

--- a/charts/rancher-monitoring/v0.1.1001/questions.yml
+++ b/charts/rancher-monitoring/v0.1.1001/questions.yml
@@ -1,1 +1,2 @@
 rancher_min_version: 2.3.4-rc1
+rancher_max_version: 2.4.7

--- a/charts/rancher-monitoring/v0.1.2/questions.yml
+++ b/charts/rancher-monitoring/v0.1.2/questions.yml
@@ -1,1 +1,2 @@
 rancher_min_version: 2.4.6-rc1
+rancher_max_version: 2.4.7


### PR DESCRIPTION
Add rancher max version to istio and monitoring app since monitoring refactor is released after 2.4.8-ent
Issue: https://github.com/cnrancher/pandaria/issues/1095