### PR TITLE
[do-not-merge] PANDARIA: global monitoring enhancement

### DIFF
--- a/charts/rancher-thanos/v0.0.4/templates/query-deployment.yaml
+++ b/charts/rancher-thanos/v0.0.4/templates/query-deployment.yaml
@@ -34,13 +34,26 @@ spec:
           - query
           {{- if .Values.clusterIds }}
           {{- range $clusterId := (split ":" .Values.clusterIds) }}
+        {{- if $.Values.collectAllCluster }}
           - --store
           - "{{ $clusterId }}:80"
+        {{- else }}
+        {{- if contains $clusterId $.Values.expectClusterIds }}
+          - --store
+          - "{{ $clusterId }}:80"
+        {{- end }}
+        {{- end }}
           {{- end }}
           {{- end }}
           {{- if .Values.thanos.store.enabled }}
           - --store
           - thanos-store-{{ .Release.Name }}:10901
+          {{- end }}
+          {{- if .Values.customStoreEndpoints }}
+          {{- range $customStoreEndpoint := .Values.customStoreEndpoints }}
+          - --store
+          - "{{ $customStoreEndpoint }}"
+          {{- end }}
           {{- end }}
           ports:
             - name: http

--- a/charts/rancher-thanos/v0.0.4/values.yaml
+++ b/charts/rancher-thanos/v0.0.4/values.yaml
@@ -9,6 +9,9 @@ clusterIds: ""
 rancherHost: ""
 token: ""
 apiToken: ""
+customStoreEndpoints: []
+expectClusterIds: ""
+collectAllCluster: true
 
 
 grpcProxyUrl: ""


### PR DESCRIPTION
1. 可以通过expectClusterIds的配置，使全局监控采集部分集群的数据
2. 支持配置customStoreEndpoints，采集用户自己启动的Prometheus监控数据

Relate issue：
https://github.com/cnrancher/pandaria/issues/891

Relate PR：
https://github.com/cnrancher/pandaria/pull/1112