### PR TITLE
PANDARIA: update global-monitoring-ui to 0.0.6

### DIFF
--- a/charts/rancher-thanos/v0.0.7/values.yaml
+++ b/charts/rancher-thanos/v0.0.7/values.yaml
@@ -127,7 +127,7 @@ ui:
   replicaCount: 1
   image:
     repository: cnrancher/global-monitoring-ui
-    tag: 0.0.5
+    tag: 0.0.6
     pullPolicy: IfNotPresent
   resources:
     limits:


### PR DESCRIPTION
监控大屏ui升级到版本0.0.6

**Relate PR:**
https://github.com/cnrancher/global-monitoring-ui/pull/254

**Relate issue:**
https://github.com/cnrancher/pandaria/issues/872