### PR TITLE
PANDARIA: Fix log-aggregator tag out of sync

### DIFF
--- a/charts/rancher-logging/0.2.2000/charts/log-aggregator/charts/log-aggregator-linux/values.yaml
+++ b/charts/rancher-logging/0.2.2000/charts/log-aggregator/charts/log-aggregator-linux/values.yaml
@@ -5,7 +5,7 @@ labels: {}
 ##
 image:
   repository: rancher/log-aggregator
-  tag: v0.1.6
+  tag: v0.1.7
 
 nodeSelector: {}
 

--- a/charts/rancher-logging/0.2.2000/charts/log-aggregator/charts/log-aggregator-windows/values.yaml
+++ b/charts/rancher-logging/0.2.2000/charts/log-aggregator/charts/log-aggregator-windows/values.yaml
@@ -5,7 +5,7 @@ labels: {}
 ##
 image:
   repository: rancher/log-aggregator
-  tag: v0.1.6
+  tag: v0.1.7
 
 nodeSelector: {}
 

--- a/charts/rancher-logging/0.2.2001/charts/log-aggregator/charts/log-aggregator-linux/values.yaml
+++ b/charts/rancher-logging/0.2.2001/charts/log-aggregator/charts/log-aggregator-linux/values.yaml
@@ -5,7 +5,7 @@ labels: {}
 ##
 image:
   repository: rancher/log-aggregator
-  tag: v0.1.6
+  tag: v0.1.7
 
 nodeSelector: {}
 

--- a/charts/rancher-logging/0.2.2001/charts/log-aggregator/charts/log-aggregator-windows/values.yaml
+++ b/charts/rancher-logging/0.2.2001/charts/log-aggregator/charts/log-aggregator-windows/values.yaml
@@ -5,7 +5,7 @@ labels: {}
 ##
 image:
   repository: rancher/log-aggregator
-  tag: v0.1.6
+  tag: v0.1.7
 
 nodeSelector: {}
 


### PR DESCRIPTION
rancher-logging (0.2.2000, 0.2.2001) 的 log-aggregator 版本为 v0.1.6, 与开源版不一致, 现修改为 v0.1.7

**Relate issue:**
https://github.com/cnrancher/pandaria/issues/1260