### PR TITLE
Add default values to Value.yaml

### DIFF
--- a/charts/rancher-monitoring/v0.1.4/values.yaml
+++ b/charts/rancher-monitoring/v0.1.4/values.yaml
@@ -84,14 +84,14 @@ exporter-kube-etcd:
     metrics:
       scheme: https
       name: metrics
-      port: 4001
+      port: 2379
       protocol: TCP
   serviceSelectorLabels:
   - "k8s-app=etcd-server"
   insecureSkipVerify: true
-  caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-  certFile: ""
-  keyFile: ""
+  caFile:  /etc/prometheus/secrets/etcd-certs/kube-ca.pem
+  certFile: /etc/prometheus/secrets/etcd-certs/kube-etcd.pem
+  keyFile: /etc/prometheus/secrets/etcd-certs/kube-etcd-key.pem
 
 exporter-kube-scheduler:
   enabled: false

--- a/charts/rancher-monitoring/v0.1.4001/values.yaml
+++ b/charts/rancher-monitoring/v0.1.4001/values.yaml
@@ -84,14 +84,14 @@ exporter-kube-etcd:
     metrics:
       scheme: https
       name: metrics
-      port: 4001
+      port: 2379
       protocol: TCP
   serviceSelectorLabels:
   - "k8s-app=etcd-server"
   insecureSkipVerify: true
-  caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-  certFile: ""
-  keyFile: ""
+  caFile:  /etc/prometheus/secrets/etcd-certs/kube-ca.pem
+  certFile: /etc/prometheus/secrets/etcd-certs/kube-etcd.pem
+  keyFile: /etc/prometheus/secrets/etcd-certs/kube-etcd-key.pem
 
 exporter-kube-scheduler:
   enabled: false

--- a/charts/rancher-monitoring/v0.1.5/values.yaml
+++ b/charts/rancher-monitoring/v0.1.5/values.yaml
@@ -84,14 +84,14 @@ exporter-kube-etcd:
     metrics:
       scheme: https
       name: metrics
-      port: 4001
+      port: 2379
       protocol: TCP
   serviceSelectorLabels:
   - "k8s-app=etcd-server"
   insecureSkipVerify: true
-  caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-  certFile: ""
-  keyFile: ""
+  caFile:  /etc/prometheus/secrets/etcd-certs/kube-ca.pem
+  certFile: /etc/prometheus/secrets/etcd-certs/kube-etcd.pem
+  keyFile: /etc/prometheus/secrets/etcd-certs/kube-etcd-key.pem
 
 exporter-kube-scheduler:
   enabled: false

--- a/charts/rancher-monitoring/v0.2.1/values.yaml
+++ b/charts/rancher-monitoring/v0.2.1/values.yaml
@@ -82,14 +82,14 @@ exporter-kube-etcd:
     metrics:
       scheme: https
       name: metrics
-      port: 4001
+      port: 2379
       protocol: TCP
   serviceSelectorLabels:
   - "k8s-app=etcd-server"
   insecureSkipVerify: true
-  caFile: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-  certFile: ""
-  keyFile: ""
+  caFile:  /etc/prometheus/secrets/etcd-certs/kube-ca.pem
+  certFile: /etc/prometheus/secrets/etcd-certs/kube-etcd.pem
+  keyFile: /etc/prometheus/secrets/etcd-certs/kube-etcd-key.pem
 
 exporter-kube-scheduler:
   enabled: false


### PR DESCRIPTION
自定义集群开启监控时，会自动的生成以下应答来监控 ETCD 服务。
prometheus.secrets[0]=''
exporter-kube-etcd.enabled=true
exporter-kube-etcd.endpoints[0]=''
exporter-kube-etcd.caFile='/etc/prometheus/secrets/etcd-certs/kube-ca.pem'
exporter-kube-etcd.certFile='/etc/prometheus/secrets/etcd-certs/kube-etcd.pem'
exporter-kube-etcd.keyFile='/etc/prometheus/secrets/etcd-certs/kube-etcd-key.pem'
exporter-kube-etcd.ports.metrics.port=2379

对于导入的 rke 或者其他类型的 K8S 集群，也可以手动添加这个几个应答实现 ETCD 服务的监控。
后面四个应答是固定的参数，chart 中没有设置默认值，或者默认值不正确。为了减少配置的复杂性，此 PR 为这些参数添加了默认值。

