### PR TITLE
[2.4] PANDARIA: Fix rancher-monitoring job BackoffLimitExceeded

### DIFF
--- a/charts/rancher-monitoring/v0.1.1000/charts/operator-init/files/crd-alertmanager.yaml
+++ b/charts/rancher-monitoring/v0.1.1000/charts/operator-init/files/crd-alertmanager.yaml
@@ -26,7 +26,6 @@ spec:
     listKind: AlertmanagerList
     plural: alertmanagers
     singular: alertmanager
-  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:

--- a/charts/rancher-monitoring/v0.1.1000/charts/operator-init/files/crd-prometheus.yaml
+++ b/charts/rancher-monitoring/v0.1.1000/charts/operator-init/files/crd-prometheus.yaml
@@ -26,7 +26,6 @@ spec:
     listKind: PrometheusList
     plural: prometheuses
     singular: prometheus
-  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:

--- a/charts/rancher-monitoring/v0.1.1000/charts/operator-init/files/crd-prometheusrules.yaml
+++ b/charts/rancher-monitoring/v0.1.1000/charts/operator-init/files/crd-prometheusrules.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: PrometheusRuleList
     plural: prometheusrules
     singular: prometheusrule
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/charts/rancher-monitoring/v0.1.1000/charts/operator-init/files/crd-servicemonitor.yaml
+++ b/charts/rancher-monitoring/v0.1.1000/charts/operator-init/files/crd-servicemonitor.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ServiceMonitorList
     plural: servicemonitors
     singular: servicemonitor
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/charts/rancher-monitoring/v0.1.1000/charts/operator-init/files/crd-thanosrulers.yaml
+++ b/charts/rancher-monitoring/v0.1.1000/charts/operator-init/files/crd-thanosrulers.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ThanosRulerList
     plural: thanosrulers
     singular: thanosruler
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/charts/rancher-monitoring/v0.1.1000/charts/operator-init/templates/job-install-crds.yaml
+++ b/charts/rancher-monitoring/v0.1.1000/charts/operator-init/templates/job-install-crds.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install, post-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
 spec:
   ttlSecondsAfterFinished: 100
   backoffLimit: 3

--- a/charts/rancher-monitoring/v0.1.1001/charts/operator-init/files/crd-alertmanager.yaml
+++ b/charts/rancher-monitoring/v0.1.1001/charts/operator-init/files/crd-alertmanager.yaml
@@ -26,7 +26,6 @@ spec:
     listKind: AlertmanagerList
     plural: alertmanagers
     singular: alertmanager
-  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:

--- a/charts/rancher-monitoring/v0.1.1001/charts/operator-init/files/crd-prometheus.yaml
+++ b/charts/rancher-monitoring/v0.1.1001/charts/operator-init/files/crd-prometheus.yaml
@@ -26,7 +26,6 @@ spec:
     listKind: PrometheusList
     plural: prometheuses
     singular: prometheus
-  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:

--- a/charts/rancher-monitoring/v0.1.1001/charts/operator-init/files/crd-prometheusrules.yaml
+++ b/charts/rancher-monitoring/v0.1.1001/charts/operator-init/files/crd-prometheusrules.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: PrometheusRuleList
     plural: prometheusrules
     singular: prometheusrule
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/charts/rancher-monitoring/v0.1.1001/charts/operator-init/files/crd-servicemonitor.yaml
+++ b/charts/rancher-monitoring/v0.1.1001/charts/operator-init/files/crd-servicemonitor.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ServiceMonitorList
     plural: servicemonitors
     singular: servicemonitor
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/charts/rancher-monitoring/v0.1.1001/charts/operator-init/files/crd-thanosrulers.yaml
+++ b/charts/rancher-monitoring/v0.1.1001/charts/operator-init/files/crd-thanosrulers.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ThanosRulerList
     plural: thanosrulers
     singular: thanosruler
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/charts/rancher-monitoring/v0.1.1001/charts/operator-init/templates/job-install-crds.yaml
+++ b/charts/rancher-monitoring/v0.1.1001/charts/operator-init/templates/job-install-crds.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install, post-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
 spec:
   ttlSecondsAfterFinished: 100
   backoffLimit: 3

--- a/charts/rancher-monitoring/v0.1.2000/charts/operator-init/files/crd-alertmanager.yaml
+++ b/charts/rancher-monitoring/v0.1.2000/charts/operator-init/files/crd-alertmanager.yaml
@@ -26,7 +26,6 @@ spec:
     listKind: AlertmanagerList
     plural: alertmanagers
     singular: alertmanager
-  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:

--- a/charts/rancher-monitoring/v0.1.2000/charts/operator-init/files/crd-prometheus.yaml
+++ b/charts/rancher-monitoring/v0.1.2000/charts/operator-init/files/crd-prometheus.yaml
@@ -26,7 +26,6 @@ spec:
     listKind: PrometheusList
     plural: prometheuses
     singular: prometheus
-  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:

--- a/charts/rancher-monitoring/v0.1.2000/charts/operator-init/files/crd-prometheusrules.yaml
+++ b/charts/rancher-monitoring/v0.1.2000/charts/operator-init/files/crd-prometheusrules.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: PrometheusRuleList
     plural: prometheusrules
     singular: prometheusrule
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/charts/rancher-monitoring/v0.1.2000/charts/operator-init/files/crd-servicemonitor.yaml
+++ b/charts/rancher-monitoring/v0.1.2000/charts/operator-init/files/crd-servicemonitor.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ServiceMonitorList
     plural: servicemonitors
     singular: servicemonitor
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/charts/rancher-monitoring/v0.1.2000/charts/operator-init/files/crd-thanosrulers.yaml
+++ b/charts/rancher-monitoring/v0.1.2000/charts/operator-init/files/crd-thanosrulers.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ThanosRulerList
     plural: thanosrulers
     singular: thanosruler
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/charts/rancher-monitoring/v0.1.2000/charts/operator-init/templates/job-install-crds.yaml
+++ b/charts/rancher-monitoring/v0.1.2000/charts/operator-init/templates/job-install-crds.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install, post-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
 spec:
   ttlSecondsAfterFinished: 100
   backoffLimit: 3

--- a/charts/rancher-monitoring/v0.1.2001/charts/operator-init/files/crd-alertmanager.yaml
+++ b/charts/rancher-monitoring/v0.1.2001/charts/operator-init/files/crd-alertmanager.yaml
@@ -26,7 +26,6 @@ spec:
     listKind: AlertmanagerList
     plural: alertmanagers
     singular: alertmanager
-  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:

--- a/charts/rancher-monitoring/v0.1.2001/charts/operator-init/files/crd-prometheus.yaml
+++ b/charts/rancher-monitoring/v0.1.2001/charts/operator-init/files/crd-prometheus.yaml
@@ -26,7 +26,6 @@ spec:
     listKind: PrometheusList
     plural: prometheuses
     singular: prometheus
-  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:

--- a/charts/rancher-monitoring/v0.1.2001/charts/operator-init/files/crd-prometheusrules.yaml
+++ b/charts/rancher-monitoring/v0.1.2001/charts/operator-init/files/crd-prometheusrules.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: PrometheusRuleList
     plural: prometheusrules
     singular: prometheusrule
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/charts/rancher-monitoring/v0.1.2001/charts/operator-init/files/crd-servicemonitor.yaml
+++ b/charts/rancher-monitoring/v0.1.2001/charts/operator-init/files/crd-servicemonitor.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ServiceMonitorList
     plural: servicemonitors
     singular: servicemonitor
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/charts/rancher-monitoring/v0.1.2001/charts/operator-init/files/crd-thanosrulers.yaml
+++ b/charts/rancher-monitoring/v0.1.2001/charts/operator-init/files/crd-thanosrulers.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ThanosRulerList
     plural: thanosrulers
     singular: thanosruler
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/charts/rancher-monitoring/v0.1.2001/charts/operator-init/templates/job-install-crds.yaml
+++ b/charts/rancher-monitoring/v0.1.2001/charts/operator-init/templates/job-install-crds.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install, post-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
 spec:
   ttlSecondsAfterFinished: 100
   backoffLimit: 3

--- a/charts/rancher-monitoring/v0.1.4000/charts/operator-init/files/crd-alertmanager.yaml
+++ b/charts/rancher-monitoring/v0.1.4000/charts/operator-init/files/crd-alertmanager.yaml
@@ -26,7 +26,6 @@ spec:
     listKind: AlertmanagerList
     plural: alertmanagers
     singular: alertmanager
-  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:

--- a/charts/rancher-monitoring/v0.1.4000/charts/operator-init/files/crd-prometheus.yaml
+++ b/charts/rancher-monitoring/v0.1.4000/charts/operator-init/files/crd-prometheus.yaml
@@ -26,7 +26,6 @@ spec:
     listKind: PrometheusList
     plural: prometheuses
     singular: prometheus
-  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:

--- a/charts/rancher-monitoring/v0.1.4000/charts/operator-init/files/crd-prometheusrules.yaml
+++ b/charts/rancher-monitoring/v0.1.4000/charts/operator-init/files/crd-prometheusrules.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: PrometheusRuleList
     plural: prometheusrules
     singular: prometheusrule
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/charts/rancher-monitoring/v0.1.4000/charts/operator-init/files/crd-servicemonitor.yaml
+++ b/charts/rancher-monitoring/v0.1.4000/charts/operator-init/files/crd-servicemonitor.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ServiceMonitorList
     plural: servicemonitors
     singular: servicemonitor
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/charts/rancher-monitoring/v0.1.4000/charts/operator-init/files/crd-thanosrulers.yaml
+++ b/charts/rancher-monitoring/v0.1.4000/charts/operator-init/files/crd-thanosrulers.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ThanosRulerList
     plural: thanosrulers
     singular: thanosruler
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/charts/rancher-monitoring/v0.1.4000/charts/operator-init/templates/job-install-crds.yaml
+++ b/charts/rancher-monitoring/v0.1.4000/charts/operator-init/templates/job-install-crds.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install, post-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
 spec:
   ttlSecondsAfterFinished: 100
   backoffLimit: 3

--- a/charts/rancher-monitoring/v0.1.4001/charts/operator-init/files/crd-alertmanager.yaml
+++ b/charts/rancher-monitoring/v0.1.4001/charts/operator-init/files/crd-alertmanager.yaml
@@ -26,7 +26,6 @@ spec:
     listKind: AlertmanagerList
     plural: alertmanagers
     singular: alertmanager
-  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:

--- a/charts/rancher-monitoring/v0.1.4001/charts/operator-init/files/crd-prometheus.yaml
+++ b/charts/rancher-monitoring/v0.1.4001/charts/operator-init/files/crd-prometheus.yaml
@@ -26,7 +26,6 @@ spec:
     listKind: PrometheusList
     plural: prometheuses
     singular: prometheus
-  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:

--- a/charts/rancher-monitoring/v0.1.4001/charts/operator-init/files/crd-prometheusrules.yaml
+++ b/charts/rancher-monitoring/v0.1.4001/charts/operator-init/files/crd-prometheusrules.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: PrometheusRuleList
     plural: prometheusrules
     singular: prometheusrule
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/charts/rancher-monitoring/v0.1.4001/charts/operator-init/files/crd-servicemonitor.yaml
+++ b/charts/rancher-monitoring/v0.1.4001/charts/operator-init/files/crd-servicemonitor.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ServiceMonitorList
     plural: servicemonitors
     singular: servicemonitor
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/charts/rancher-monitoring/v0.1.4001/charts/operator-init/files/crd-thanosrulers.yaml
+++ b/charts/rancher-monitoring/v0.1.4001/charts/operator-init/files/crd-thanosrulers.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ThanosRulerList
     plural: thanosrulers
     singular: thanosruler
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/charts/rancher-monitoring/v0.1.4001/charts/operator-init/templates/job-install-crds.yaml
+++ b/charts/rancher-monitoring/v0.1.4001/charts/operator-init/templates/job-install-crds.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install, post-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
 spec:
   ttlSecondsAfterFinished: 100
   backoffLimit: 3

--- a/charts/rancher-monitoring/v0.1.5000/charts/operator-init/files/crd-alertmanager.yaml
+++ b/charts/rancher-monitoring/v0.1.5000/charts/operator-init/files/crd-alertmanager.yaml
@@ -26,7 +26,6 @@ spec:
     listKind: AlertmanagerList
     plural: alertmanagers
     singular: alertmanager
-  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:

--- a/charts/rancher-monitoring/v0.1.5000/charts/operator-init/files/crd-prometheus.yaml
+++ b/charts/rancher-monitoring/v0.1.5000/charts/operator-init/files/crd-prometheus.yaml
@@ -26,7 +26,6 @@ spec:
     listKind: PrometheusList
     plural: prometheuses
     singular: prometheus
-  preserveUnknownFields: false
   scope: Namespaced
   subresources: {}
   validation:

--- a/charts/rancher-monitoring/v0.1.5000/charts/operator-init/files/crd-prometheusrules.yaml
+++ b/charts/rancher-monitoring/v0.1.5000/charts/operator-init/files/crd-prometheusrules.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: PrometheusRuleList
     plural: prometheusrules
     singular: prometheusrule
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/charts/rancher-monitoring/v0.1.5000/charts/operator-init/files/crd-servicemonitor.yaml
+++ b/charts/rancher-monitoring/v0.1.5000/charts/operator-init/files/crd-servicemonitor.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ServiceMonitorList
     plural: servicemonitors
     singular: servicemonitor
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/charts/rancher-monitoring/v0.1.5000/charts/operator-init/files/crd-thanosrulers.yaml
+++ b/charts/rancher-monitoring/v0.1.5000/charts/operator-init/files/crd-thanosrulers.yaml
@@ -14,7 +14,6 @@ spec:
     listKind: ThanosRulerList
     plural: thanosrulers
     singular: thanosruler
-  preserveUnknownFields: false
   scope: Namespaced
   validation:
     openAPIV3Schema:

--- a/charts/rancher-monitoring/v0.1.5000/charts/operator-init/templates/job-install-crds.yaml
+++ b/charts/rancher-monitoring/v0.1.5000/charts/operator-init/templates/job-install-crds.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-install, post-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": hook-succeeded, before-hook-creation
 spec:
   ttlSecondsAfterFinished: 100
   backoffLimit: 3


### PR DESCRIPTION
- prometheus-operator 新版本已移除 preserveUnknownFields 字段，更新 crd 文件
- job-install-crds 添加删除策略钩子 before-hook-creation 解决出现 job 报错后残留问题

**Relate issue:**
https://github.com/cnrancher/pandaria/issues/1344