### PR TITLE
[2.4] PANDARIA: fix deploy cluster-alerting error

### DIFF
--- a/charts/rancher-monitoring/v0.1.5004/charts/alertmanager/templates/alertmanager.yaml
+++ b/charts/rancher-monitoring/v0.1.5004/charts/alertmanager/templates/alertmanager.yaml
@@ -28,14 +28,22 @@ spec:
     {{ (index $pair 0) }}: ""
     {{- end }}
     {{- end }}
-  clusterAdvertiseAddress: {{ .Values.clusterAdvertiseAddress }} 
+  {{ if .Values.clusterAdvertiseAddress -}}
+  clusterAdvertiseAddress: {{ .Values.clusterAdvertiseAddress }}
+  {{- end }} 
   {{ if .Values.additionalPeers -}}
   additionalPeers:
 {{ toYaml .Values.additionalPeers | indent 2 }}
   {{- end }}  
-  clusterPeerTimeout: {{ .Values.clusterPeerTimeout }} 
-  clusterGossipInterval: {{ .Values.clusterGossipInterval }} 
+  {{ if .Values.clusterPeerTimeout -}}
+  clusterPeerTimeout: {{ .Values.clusterPeerTimeout }}
+  {{- end }}  
+  {{ if .Values.clusterGossipInterval -}}
+  clusterGossipInterval: {{ .Values.clusterGossipInterval }}
+  {{- end }}  
+  {{ if .Values.clusterPushpullInterval -}}
   clusterPushpullInterval: {{ .Values.clusterPushpullInterval }}
+  {{- end }}  
   paused: {{ .Values.paused }}
   replicas: {{ .Values.replicaCount }}
   logLevel:  {{ .Values.logLevel }}

--- a/charts/rancher-monitoring/v0.1.5004/charts/operator/templates/deployment.yaml
+++ b/charts/rancher-monitoring/v0.1.5004/charts/operator/templates/deployment.yaml
@@ -48,8 +48,6 @@ spec:
             - --prometheus-config-reloader={{ template "system_default_registry" . }}{{ .Values.image.prometheusConfigReloader.repository }}:{{ .Values.image.prometheusConfigReloader.tag }}
             - --config-reloader-image={{ template "system_default_registry" . }}{{ .Values.image.configmapReload.repository }}:{{ .Values.image.configmapReload.tag }}
             - --labels={{ .Values.apiGroup }}=true
-            - --manage-crds={{ .Values.manageCRDs }}
-            - --with-validation={{ .Values.withValidation }}
           ports:
           - containerPort: 8080
             name: http

--- a/charts/rancher-monitoring/v0.1.5004/values.yaml
+++ b/charts/rancher-monitoring/v0.1.5004/values.yaml
@@ -22,8 +22,6 @@ operator:
   tolerations: []
   logFormat: "logfmt"
   logLevel: "info"
-  manageCRDs: false
-  withValidation: true
   ## Already exist ServiceAccount
   ##
   serviceAccountName: ""


### PR DESCRIPTION
1. 修复较低的k8s版本出现cluster-alerting部署失败的问题
2. prometheus-operator移除manage-crds和with-validation参数

**Relate issue**
https://github.com/cnrancher/pandaria/issues/1826
https://github.com/cnrancher/pandaria/issues/1788